### PR TITLE
Fix shebang for `bot.py`

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env/python 3
+#!/usr/bin/env python3
+
 import os
 import database
 import time


### PR DESCRIPTION
Properly runs `env` in order to resolve `python3` - calling `python 3` causes an error on Debian bookworm 5.10.81.1-microsoft-standard-WSL2